### PR TITLE
Reject prefill batches that exceed KV capacity

### DIFF
--- a/src/core/engine/sim/run/prefill.ts
+++ b/src/core/engine/sim/run/prefill.ts
@@ -1,10 +1,12 @@
 import { roleSize, totalChips } from '../../surface/deploy';
+import type { Diagnostic } from '../../surface/deploy';
 import type { CostBackend } from '../cost/types';
 import { lowerStage } from '../lowering/lower';
 import { partitionIntoStages } from '../lowering/stages';
 import type { EvalOptions, PrefillEvaluation, SimInput } from '../../surface/api';
 import { runnableOn, validateInput } from './validate';
 import { runPipeline } from './common';
+import { memoryFootprint } from './memory';
 
 export function evaluatePrefill<TBackend extends CostBackend>(
   input: SimInput,
@@ -16,7 +18,11 @@ export function evaluatePrefill<TBackend extends CostBackend>(
   const T = workload.prefillLen;
 
   const diags = validateInput(input);
-  if (diags.some((x) => x.severity === 'error')) return { ok: false, diags };
+  const fail = (extra?: Diagnostic): PrefillEvaluation<TBackend> => ({
+    ok: false,
+    diags: extra ? [...diags, extra] : diags,
+  });
+  if (diags.some((x) => x.severity === 'error')) return fail();
 
   // validate saw the model as written; lower the model as this chip runs it
   const model = runnableOn(input.model, deployment.chip);
@@ -25,6 +31,16 @@ export function evaluatePrefill<TBackend extends CostBackend>(
   const pp = roleSize(deployment.mesh, 'PP');
 
   const stages = partitionIntoStages(model, pp);
+  const memory = memoryFootprint(model, deployment, stages, T);
+  // Throughput keeps one microbatch on every pipeline stage. TTFT runs
+  // one request through the stages in sequence, so it has no PP multiplier.
+  const residentSeqsPerChip = mode === 'throughput' ? (seqs / dpa) * pp : seqs;
+  if (!opts.ignoreKvCapacity && residentSeqsPerChip > memory.maxResidentSeqsPerChip)
+    return fail({
+      severity: 'error',
+      code: 'kv-no-room',
+      message: `${residentSeqsPerChip} resident sequences per chip exceed the ${memory.maxResidentSeqsPerChip} that fit in KV`,
+    });
 
   const run = runPipeline(input, stages, opts, (stage) =>
     lowerStage(

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from 'vitest';
 import { evaluatePrefill } from '../src/core/engine/sim/run/prefill';
 import { evaluateDecodeAtBatch } from '../src/core/engine/sim/run/decode';
+import { memoryFootprint } from '../src/core/engine/sim/run/memory';
+import { partitionIntoStages } from '../src/core/engine/sim/lowering/stages';
 import { makeNaiveOpCostSumBackend } from '../src/core/engine/sim/cost/naiveOpCostSum';
 import { naiveOpCost } from '../src/core/engine/sim/cost/helpers/naiveOpCost';
 import { OpId } from '../src/core/engine/sim/ir/ops';
@@ -31,6 +33,56 @@ test('validateInput gates weights past HBM capacity', () => {
     workload: { prefillLen: 128, generateLen: 0 },
   });
   expect(diags.map((x) => x.code)).toContain('weights-dont-fit');
+});
+
+test('prefill capacity counts DPA groups and pipeline microbatches', () => {
+  const model = MODEL_PRESETS.find((m) => m.name === 'LLaMA 3 8B')!;
+  const workload = { prefillLen: 512, generateLen: 256 };
+  const axes = deployedAxes(h100.interconnect, { domain: 8, nodes: 1 });
+  const mesh = makeMesh(
+    axes,
+    { DPA: ['D1'], TP: [], EP: [], ETP: ['D1'], PP: ['D0'] },
+    { D: [2, 4] },
+  );
+  const deployment = (chip: ChipSpec): Deployment => ({
+    chip,
+    mesh,
+    moeDispatch: 'ring-of-experts',
+  });
+  const stages = partitionIntoStages(model, 2);
+  const perStage = stages.map((stage) =>
+    memoryFootprint(model, deployment(idealTiles), [stage], workload.prefillLen),
+  );
+  const chipWithCapacity = (residentSeqs: number): ChipSpec => ({
+    ...idealTiles,
+    hbmCapacity: Math.max(
+      ...perStage.map(
+        (memory) => memory.weightBytesPerChip + residentSeqs * memory.kvBytesPerSeqPerChip,
+      ),
+    ),
+  });
+  const input = { model, deployment: deployment(chipWithCapacity(2)), workload };
+
+  expect(memoryFootprint(model, input.deployment, stages, workload.prefillLen)).toMatchObject({
+    maxResidentSeqsPerChip: 2,
+  });
+  expect(
+    memoryFootprint(model, input.deployment, stages, workload.prefillLen + workload.generateLen),
+  ).toMatchObject({ maxResidentSeqsPerChip: 1 });
+  expect(evaluatePrefill(input, 4, 'throughput', { costBackend: backend }).ok).toBe(true);
+
+  const overflow = evaluatePrefill(input, 8, 'throughput', { costBackend: backend });
+  expect(overflow.ok).toBe(false);
+  expect(overflow.diags.map((diag) => diag.code)).toContain('kv-no-room');
+  expect(
+    evaluatePrefill(input, 8, 'throughput', { costBackend: backend, ignoreKvCapacity: true }).ok,
+  ).toBe(true);
+
+  const ttftInput = { model, deployment: deployment(chipWithCapacity(1)), workload };
+  expect(memoryFootprint(model, ttftInput.deployment, stages, workload.prefillLen)).toMatchObject({
+    maxResidentSeqsPerChip: 1,
+  });
+  expect(evaluatePrefill(ttftInput, 1, 'ttft', { costBackend: backend }).ok).toBe(true);
 });
 
 test('a width the chip has no unit for widens to one it has, with a warning', () => {


### PR DESCRIPTION
## Summary

- Reject throughput-prefill batches when weights and resident prompt KV exceed per-chip HBM.
- Count one microbatch per pipeline stage and divide each microbatch across DPA groups.
- Keep TTFT at one resident request and preserve `ignoreKvCapacity`.

## Why

`evaluateDecodeAtBatch` already rejects KV-overflow batches. `evaluatePrefill` did not, so search and direct evaluation could report throughput for a batch that could not fit.

The check uses `memoryFootprint`, so it follows each model's attention type, weight placement, TP, DCP, expert placement, and pipeline stage split. It checks prompt-length KV because generation has not happened during prefill.

This change covers the existing weights-plus-KV memory model. Prefill activation workspace remains outside `memoryFootprint`.

## Tests

- `npm run build`
- `vitest run --maxWorkers=1 --minWorkers=1` (86 tests)
- Capacity boundary audit across all 17 presets and 248 feasible 8× H100 role-size deployments