### PR TITLE
fix: pad MoE expert GEMMs to the chip's smallest MMA shape

### DIFF
--- a/src/core/engine/sim/cost/helpers/naiveOpCost.ts
+++ b/src/core/engine/sim/cost/helpers/naiveOpCost.ts
@@ -1,7 +1,7 @@
 import { collectiveCost } from './collectives';
 import { ExpandedOp } from '../../ir/ops';
 import { localElems, shardWays } from '../../ir/tensors';
-import { DEFAULT_MATMUL_SAT_ROWS, peakFlops } from '../../../../hardware/chips';
+import { DEFAULT_MATMUL_SAT_ROWS, groupPadRows, peakFlops } from '../../../../hardware/chips';
 import type { HardwareResource } from '../../../surface/api';
 import type { Deployment } from '../../../surface/deploy';
 import { DTYPE_BYTES, type Dtype } from '../../../../model/dtype';
@@ -14,13 +14,21 @@ export type OpCost = Record<HardwareResource, number>;
 // slicing a projection) idles the array's columns or depth exactly like
 // a short M idles its rows. Grouped GEMMs pad rows per activated group
 // (multinomial token counts smooth the per-group ceiling, keep the
-// floor: every activated group pads to one tile).
-function tileUtil(m: number, n: number, k: number, groups: number, tile: number): number {
+// floor: every activated group pays `groupRows`, the chip's cheapest
+// single MMA instruction, see ChipSpec.mmaShapes).
+function tileUtil(
+  m: number,
+  n: number,
+  k: number,
+  groups: number,
+  tile: number,
+  groupRows: number,
+): number {
   // tile 1 = no tiling at all (fractional dims, e.g. MLA's equivalent
   // columns, must not round)
   if (tile <= 1 || m <= 0 || n <= 0 || k <= 0) return 1;
   const pad = (d: number) => tile * Math.ceil(d / tile);
-  const rows = groups <= 1 ? pad(m) : Math.max(m, groups * tile);
+  const rows = groups <= 1 ? pad(m) : Math.max(m, groups * groupRows);
   return (m * n * k) / (rows * pad(n) * pad(k));
 }
 
@@ -47,6 +55,7 @@ export function naiveOpCost(op: ExpandedOp, deployment: Deployment): OpCost {
         kLocal,
         op.groups ?? 1,
         chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS,
+        groupPadRows(chip),
       );
       return {
         compute: (2 * mLocal * kLocal * nLocal) / (rate(op.dtype) * util),

--- a/src/core/engine/sim/cost/helpers/naiveOpCost.ts
+++ b/src/core/engine/sim/cost/helpers/naiveOpCost.ts
@@ -1,7 +1,12 @@
 import { collectiveCost } from './collectives';
 import { ExpandedOp } from '../../ir/ops';
 import { localElems, shardWays } from '../../ir/tensors';
-import { DEFAULT_MATMUL_SAT_ROWS, groupPadRows, peakFlops } from '../../../../hardware/chips';
+import {
+  type ChipSpec,
+  DEFAULT_MATMUL_SAT_ROWS,
+  groupedRows,
+  peakFlops,
+} from '../../../../hardware/chips';
 import type { HardwareResource } from '../../../surface/api';
 import type { Deployment } from '../../../surface/deploy';
 import { DTYPE_BYTES, type Dtype } from '../../../../model/dtype';
@@ -12,23 +17,23 @@ export type OpCost = Record<HardwareResource, number>;
 // every edge (a 128x128 MXU, 128-row tensor-core macro-tiles), so all
 // three GEMM dims pad up to it. A thin N or K shard (deep TP/ETP
 // slicing a projection) idles the array's columns or depth exactly like
-// a short M idles its rows. Grouped GEMMs pad rows per activated group
-// (multinomial token counts smooth the per-group ceiling, keep the
-// floor: every activated group pays `groupRows`, the chip's cheapest
-// single MMA instruction, see ChipSpec.mmaShapes).
+// a short M idles its rows. Grouped GEMMs (groups defined, even if 1)
+// pad rows per activated group instead (multinomial token counts smooth
+// the per-group ceiling, keep the floor: every activated group pays at
+// least one MMA instruction, see groupedRows).
 function tileUtil(
+  chip: ChipSpec,
   m: number,
   n: number,
   k: number,
-  groups: number,
-  tile: number,
-  groupRows: number,
+  groups: number | undefined,
 ): number {
+  const tile = chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS;
   // tile 1 = no tiling at all (fractional dims, e.g. MLA's equivalent
   // columns, must not round)
   if (tile <= 1 || m <= 0 || n <= 0 || k <= 0) return 1;
   const pad = (d: number) => tile * Math.ceil(d / tile);
-  const rows = groups <= 1 ? pad(m) : Math.max(m, groups * groupRows);
+  const rows = groups === undefined ? pad(m) : groupedRows(chip, m, groups);
   return (m * n * k) / (rows * pad(n) * pad(k));
 }
 
@@ -49,14 +54,7 @@ export function naiveOpCost(op: ExpandedOp, deployment: Deployment): OpCost {
       const mLocal = m / shardWays(op.x.sharding[0], dims);
       const kLocal = k / shardWays(op.x.sharding[1], dims);
       const nLocal = op.w.shape[last] / shardWays(op.w.sharding[last], dims);
-      const util = tileUtil(
-        mLocal,
-        nLocal,
-        kLocal,
-        op.groups ?? 1,
-        chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS,
-        groupPadRows(chip),
-      );
+      const util = tileUtil(chip, mLocal, nLocal, kLocal, op.groups);
       return {
         compute: (2 * mLocal * kLocal * nLocal) / (rate(op.dtype) * util),
         memory: (mLocal * (kLocal + nLocal) * DTYPE_BYTES[op.dtype]) / hbm,

--- a/src/core/hardware/chips.ts
+++ b/src/core/hardware/chips.ts
@@ -46,10 +46,22 @@ export interface ChipSpec {
   // DEFAULT_MATMUL_SAT_ROWS = 128, since TPU MXUs are 128x128 and
   // H100-class GEMMs want >=128-row tiles.
   matmulSatRows?: number;
+  // Row (M) shapes of the chip's matmul instructions and the fraction of
+  // peak each sustains. A grouped GEMM (MoE experts) pads every activated
+  // group to the cheapest one rather than to a saturating matmulSatRows
+  // tile: a 2-token expert costs one m16 mma.sync on Hopper, not 128 rows.
+  // Omitted = a single full-rate matmulSatRows shape.
+  mmaShapes?: { m: number; rate: number }[];
 }
 
 // Fallback ChipSpec.matmulSatRows, see that field's doc.
 export const DEFAULT_MATMUL_SAT_ROWS = 128;
+
+// Full-rate row equivalents one activated group of a grouped GEMM pays.
+export function groupPadRows(chip: ChipSpec): number {
+  const shapes = chip.mmaShapes ?? [{ m: chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS, rate: 1 }];
+  return Math.min(...shapes.map((s) => s.m / s.rate));
+}
 
 // What a format degrades to when a chip has no matmul unit for it: each names
 // the next format its data can be unpacked into, and following the chain gives
@@ -167,6 +179,12 @@ export const CHIPS: ChipSpec[] = [
     },
     // measured: sustained GEMM ~720-794/989 TF bf16, fp8 fraction lower
     // (SemiAnalysis/MAMF); BabelStream copy/triad ~0.9
+    // wgmma m64 at full rate; legacy mma.sync m16 sustains ~2/3 of peak
+    // (Luo et al. 2024, arXiv:2402.13499, measured ~63-67% on H800)
+    mmaShapes: [
+      { m: 64, rate: 1 },
+      { m: 16, rate: 0.67 },
+    ],
     realizableFlopsFrac: 0.75,
     realizableHbmBwFrac: 0.9,
     costPerHour: 1.8,
@@ -197,6 +215,10 @@ export const CHIPS: ChipSpec[] = [
       scaleOut: { bandwidthPerChip: 50e9, latency: 5e-6, maxNodes: 8 },
     },
     // same GH100 silicon: sustained GEMM as H100; copy kernels ~0.85-0.9
+    mmaShapes: [
+      { m: 64, rate: 1 },
+      { m: 16, rate: 0.67 },
+    ],
     realizableFlopsFrac: 0.75,
     realizableHbmBwFrac: 0.9,
     costPerHour: 2.25,
@@ -228,6 +250,12 @@ export const CHIPS: ChipSpec[] = [
     },
     // measured: MAMF 1745/2250 TF bf16, fp8 ~0.76; copy kernels 6.6-7 TB/s
     // and improving with drivers
+    // tcgen05.mma M=128 fills the datapath; M=64 drives half of it (PTX ISA,
+    // tcgen05 data-path layouts), so a small group pays a full 128 either way
+    mmaShapes: [
+      { m: 128, rate: 1 },
+      { m: 64, rate: 0.5 },
+    ],
     realizableFlopsFrac: 0.75,
     realizableHbmBwFrac: 0.85,
     costPerHour: 3.6,
@@ -256,6 +284,10 @@ export const CHIPS: ChipSpec[] = [
     // head count divides by, leaving those chips with no role to fill.
     interconnect: { bandwidthPerChip: 900e9, latency: 2e-6, domainSize: 64 },
     // B200 silicon at a higher datasheet clock: MAMF 1822/2500, same HBM
+    mmaShapes: [
+      { m: 128, rate: 1 },
+      { m: 64, rate: 0.5 },
+    ],
     realizableFlopsFrac: 0.75,
     realizableHbmBwFrac: 0.85,
     costPerHour: 4.5,
@@ -294,6 +326,10 @@ export const CHIPS: ChipSpec[] = [
       domainSize: 8,
       scaleOut: { bandwidthPerChip: 100e9, latency: 5e-6, maxNodes: 8 },
     },
+    mmaShapes: [
+      { m: 128, rate: 1 },
+      { m: 64, rate: 0.5 },
+    ],
     realizableFlopsFrac: 0.75,
     realizableHbmBwFrac: 0.85,
     costPerHour: 5.4,
@@ -453,6 +489,8 @@ export const CHIPS: ChipSpec[] = [
     // sustained clock ~1.2 of the 2.1 GHz boost the datasheet assumes: tuned
     // GEMMs 620-708/1307 TF bf16 (SemiAnalysis/AMD MAF); BabelStream
     // 3.9-4.3/5.3 TB/s
+    // MFMA 16x16xK is a full-rate instruction on CDNA3/CDNA4
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.5,
     realizableHbmBwFrac: 0.8,
     costPerHour: 2.16,
@@ -481,6 +519,7 @@ export const CHIPS: ChipSpec[] = [
     },
     // same silicon at 1000 W sustains higher clocks: AMD MAF 843/1307 TF; HBM
     // fraction inferred from MI300X
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.6,
     realizableHbmBwFrac: 0.8,
     costPerHour: 2.7,
@@ -512,6 +551,7 @@ export const CHIPS: ChipSpec[] = [
     },
     // measured: HipKittens ~1610/2500 TF bf16, fp8 ~0.65; streaming reads
     // ~5.8/8 TB/s
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.65,
     realizableHbmBwFrac: 0.7,
     costPerHour: 3.6,

--- a/src/core/hardware/chips.ts
+++ b/src/core/hardware/chips.ts
@@ -35,22 +35,26 @@ export interface ChipSpec {
   tdp?: number;
   // Fraction of the datasheet matmul rate a well-tuned, well-shaped GEMM
   // sustains (sustained clocks, kernel quality). Derates compute pricing
-  // only; shape-dependent padding is priced separately via matmulSatRows.
+  // only; shape-dependent padding is priced separately via matmulSatRows
+  // and mmaShapes.
   realizableFlopsFrac: number;
   // Fraction of hbmBandwidth a well-tuned streaming kernel sustains;
   // derates every memory price.
   realizableHbmBwFrac: number;
   // Edge of the matmul array's tile: every GEMM dim (M, N and K) pads up
   // to it, so thin shards run at padded-volume utilization (a 64-deep
-  // contraction on a 128x128 MXU idles half the array).
+  // contraction on a 128x128 MXU idles half the array). A grouped GEMM's
+  // rows pad to mmaShapes instead (its N and K still pad here).
   // DEFAULT_MATMUL_SAT_ROWS = 128, since TPU MXUs are 128x128 and
   // H100-class GEMMs want >=128-row tiles.
   matmulSatRows?: number;
-  // Row (M) shapes of the chip's matmul instructions and the fraction of
-  // peak each sustains. A grouped GEMM (MoE experts) runs on the shape
-  // that is cheapest for its rows, padding every activated group to that
-  // shape rather than to a saturating matmulSatRows tile: a 2-token expert
-  // costs one m16 mma.sync on Hopper, not 128 rows.
+  // Row (M) shapes of the chip's matmul instructions and the throughput
+  // each sustains relative to the chip's full-rate shape (it stacks on
+  // realizableFlopsFrac, so enter mma.sync/wgmma, not mma.sync/peak). A
+  // grouped GEMM (MoE experts) runs on the shape that is cheapest for its
+  // rows, padding every activated group to that shape rather than to a
+  // saturating matmulSatRows tile: a 2-token expert costs one m16
+  // mma.sync on Hopper, not 128 rows.
   // Omitted = a single full-rate matmulSatRows shape.
   mmaShapes?: { m: number; rate: number }[];
 }
@@ -59,11 +63,13 @@ export interface ChipSpec {
 export const DEFAULT_MATMUL_SAT_ROWS = 128;
 
 // Full-rate row equivalents a grouped GEMM of m rows over `groups` activated
-// groups pays: every group issues at least one instruction and every row
-// runs at that instruction's rate, on whichever shape makes that cheapest.
+// groups pays: every group issues at least one instruction (the floor), the
+// rows still come in whole instructions (the ceiling, at the shape's own
+// granularity, so a one-group GEMM never undercuts the dense path) and every
+// row runs at that instruction's rate, on whichever shape makes that cheapest.
 export function groupedRows(chip: ChipSpec, m: number, groups: number): number {
   const shapes = chip.mmaShapes ?? [{ m: chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS, rate: 1 }];
-  return Math.min(...shapes.map((s) => Math.max(m, groups * s.m) / s.rate));
+  return Math.min(...shapes.map((s) => Math.max(s.m * Math.ceil(m / s.m), groups * s.m) / s.rate));
 }
 
 // What a format degrades to when a chip has no matmul unit for it: each names
@@ -150,6 +156,8 @@ export const CHIPS: ChipSpec[] = [
       scaleOut: { bandwidthPerChip: 25e9, latency: 5e-6, maxNodes: 8 },
     },
     // measured: MAMF 271/312 TF bf16; BabelStream 1.73/2.04 TB/s
+    // mma.sync m16n8k16 is Ampere's only tensor-core path, at full rate
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.85,
     realizableHbmBwFrac: 0.85,
     costPerHour: 0.81,
@@ -393,6 +401,8 @@ export const CHIPS: ChipSpec[] = [
     },
     // measured: cuBLAS 386/504 TF bf16 (ungated part); GDDR7 fraction inferred
     // from the 5090's subsystem
+    // sm_120 has no tcgen05/wgmma: mma.sync m16 is its full-rate instruction
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.75,
     realizableHbmBwFrac: 0.9,
     costPerHour: 1.26,
@@ -428,6 +438,8 @@ export const CHIPS: ChipSpec[] = [
     },
     // GeForce datasheet tensor rates already carry the fp32-accumulate gate, so
     // tuned GEMMs land at ~1.0x datasheet; streaming reads 1.67/1.79 TB/s
+    // sm_120 has no tcgen05/wgmma: mma.sync m16 is its full-rate instruction
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.95,
     realizableHbmBwFrac: 0.95,
     costPerHour: 0.54,
@@ -460,6 +472,8 @@ export const CHIPS: ChipSpec[] = [
       scaleOut: { bandwidthPerChip: 12.5e9, latency: 10e-6, maxNodes: 8 },
     },
     // gated datasheet as above: fp32-acc GEMMs ~1.0x datasheet; streaming ~0.9
+    // Ada, like Ampere: mma.sync m16 is the only tensor-core path, full rate
+    mmaShapes: [{ m: 16, rate: 1 }],
     realizableFlopsFrac: 0.95,
     realizableHbmBwFrac: 0.9,
     costPerHour: 0.36,

--- a/src/core/hardware/chips.ts
+++ b/src/core/hardware/chips.ts
@@ -47,9 +47,10 @@ export interface ChipSpec {
   // H100-class GEMMs want >=128-row tiles.
   matmulSatRows?: number;
   // Row (M) shapes of the chip's matmul instructions and the fraction of
-  // peak each sustains. A grouped GEMM (MoE experts) pads every activated
-  // group to the cheapest one rather than to a saturating matmulSatRows
-  // tile: a 2-token expert costs one m16 mma.sync on Hopper, not 128 rows.
+  // peak each sustains. A grouped GEMM (MoE experts) runs on the shape
+  // that is cheapest for its rows, padding every activated group to that
+  // shape rather than to a saturating matmulSatRows tile: a 2-token expert
+  // costs one m16 mma.sync on Hopper, not 128 rows.
   // Omitted = a single full-rate matmulSatRows shape.
   mmaShapes?: { m: number; rate: number }[];
 }
@@ -57,10 +58,12 @@ export interface ChipSpec {
 // Fallback ChipSpec.matmulSatRows, see that field's doc.
 export const DEFAULT_MATMUL_SAT_ROWS = 128;
 
-// Full-rate row equivalents one activated group of a grouped GEMM pays.
-export function groupPadRows(chip: ChipSpec): number {
+// Full-rate row equivalents a grouped GEMM of m rows over `groups` activated
+// groups pays: every group issues at least one instruction and every row
+// runs at that instruction's rate, on whichever shape makes that cheapest.
+export function groupedRows(chip: ChipSpec, m: number, groups: number): number {
   const shapes = chip.mmaShapes ?? [{ m: chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS, rate: 1 }];
-  return Math.min(...shapes.map((s) => s.m / s.rate));
+  return Math.min(...shapes.map((s) => Math.max(m, groups * s.m) / s.rate));
 }
 
 // What a format degrades to when a chip has no matmul unit for it: each names

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -254,6 +254,59 @@ test('thin GEMM dims pay tile padding', () => {
   expect(time(256, 128, 128) / full).toBeCloseTo(2, 9);
 });
 
+test('a grouped GEMM pads each group to the cheapest MMA instruction', () => {
+  const time = (chip: ChipSpec, groups: number) =>
+    naiveOpCost(
+      {
+        kind: 'gemm',
+        id: 'g' as OpId,
+        label: 'g',
+        deps: [],
+        x: tt([256, 128]),
+        w: tt([groups, 128, 128]),
+        out: tt([256, 128]),
+        dtype: 'bf16',
+        groups,
+      },
+      singleChip(chip),
+    ).compute;
+  // 256 rows over 111 groups (gpt-oss-120b top-4 at 64 tokens): Hopper
+  // pays one m16 mma.sync at 2/3 rate per group, not a 128-row tile
+  expect(time(h100, 111) / time(h100, 1)).toBeCloseTo((111 * 16) / 0.67 / 256, 9);
+  // Blackwell's m64 half-datapath shape is no cheaper than its m128
+  expect(time(CHIPS_BY_ID['b200'], 111) / time(CHIPS_BY_ID['b200'], 1)).toBeCloseTo(
+    (111 * 128) / 256,
+    9,
+  );
+  // without mmaShapes every group pays a saturating matmulSatRows tile
+  const noShapes: ChipSpec = { ...h100, mmaShapes: undefined };
+  expect(time(noShapes, 111) / time(noShapes, 1)).toBeCloseTo((111 * 128) / 256, 9);
+});
+
+test('gpt-oss-120b decode on one H200 stays under the measured step time', () => {
+  // InferenceX gptoss-fp4-h200-trt, TP=1, 1k/1k, concurrency 64: median
+  // TPOT 22.5 ms (github.com/SemiAnalysisAI/InferenceX, run 26016892349)
+  const measured = 22.5e-3;
+  const model = MODEL_PRESETS.find((m) => m.name === 'gpt-oss-120b MXFP4/BF16')!;
+  const h200 = CHIPS_BY_ID['h200-sxm'];
+  const step = (chip: ChipSpec) => {
+    const r = evaluateDecodeAtBatch(
+      { model, deployment: singleChip(chip), workload: { prefillLen: 1024, generateLen: 1024 } },
+      64,
+      1,
+      { costBackend: makeNaiveOpCostSumBackend({ memoryOverlap: 0.9, commsOverlap: 0.65 }) },
+    );
+    if (!r.ok) throw new Error(r.diags.map((x) => x.message).join(', '));
+    return r;
+  };
+  const fixed = step(h200);
+  expect(fixed.stepTime).toBeLessThan(measured);
+  expect(fixed.cost.busy.memory).toBeGreaterThan(fixed.cost.busy.compute);
+  // padding every expert to matmulSatRows made the same step compute-bound
+  // and slower than the engine
+  expect(step({ ...h200, mmaShapes: undefined }).stepTime).toBeGreaterThan(measured);
+});
+
 test('a gemm charges its activation streams to memory', () => {
   const ctx = singleChip(h100);
   const [m, k, n] = [256, 512, 1024];

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -9,7 +9,7 @@ import { OpId } from '../src/core/engine/sim/ir/ops';
 import { localElems, tt } from '../src/core/engine/sim/ir/tensors';
 import { runnableOn, validateInput } from '../src/core/engine/sim/run/validate';
 import { Deployment, makeMesh, MoeDispatch } from '../src/core/engine/surface/deploy';
-import { ChipSpec, CHIPS_BY_ID, peakFlops, runsAs } from '../src/core/hardware/chips';
+import { ChipSpec, CHIPS, CHIPS_BY_ID, peakFlops, runsAs } from '../src/core/hardware/chips';
 import { deployedAxes } from '../src/core/hardware/topology';
 import { gqa } from '../src/core/model/block/attn';
 import { MlpConfig, moeMlp } from '../src/core/model/block/mlp';
@@ -277,6 +277,12 @@ test('a grouped GEMM pads each group to the cheapest MMA instruction', () => {
   // one 2-row expert per chip (EP = experts) is still a grouped GEMM: one
   // m16, not a dense 128-row tile
   expect(time(h100, 2, 1) / dense).toBeCloseTo(16 / 0.67 / 256, 9);
+  // but a one-group GEMM with rows to fill tiles never undercuts the dense
+  // GEMM of the same shape: 100 rows are two m64 either way
+  expect(time(h100, 100, 1)).toBeCloseTo(time(h100, 100), 9);
+  // Ampere's only instruction is a full-rate m16: one per group
+  const a100 = CHIPS_BY_ID['a100-sxm'];
+  expect(time(a100, 256, 111) / time(a100, 256)).toBeCloseTo((111 * 16) / 256, 9);
   // 32 rows per group fill m16 instructions, so all rows run at 2/3 rate
   expect(time(h100, 4096, 128) / dense).toBeCloseTo(4096 / 0.67 / 256, 9);
   // enough rows per group and m64 at full rate wins again
@@ -287,6 +293,18 @@ test('a grouped GEMM pads each group to the cheapest MMA instruction', () => {
   // without mmaShapes every group pays a saturating matmulSatRows tile
   const noShapes: ChipSpec = { ...h100, mmaShapes: undefined };
   expect(time(noShapes, 256, 111) / time(noShapes, 256)).toBeCloseTo((111 * 128) / 256, 9);
+});
+
+test('every mmaShapes entry has a positive m and a rate in (0, 1]', () => {
+  for (const chip of CHIPS) {
+    if (chip.mmaShapes === undefined) continue;
+    expect(chip.mmaShapes.length).toBeGreaterThan(0);
+    for (const s of chip.mmaShapes) {
+      expect(s.m).toBeGreaterThan(0);
+      expect(s.rate).toBeGreaterThan(0);
+      expect(s.rate).toBeLessThanOrEqual(1);
+    }
+  }
 });
 
 test('gpt-oss-120b decode on one H200 stays under the measured step time', () => {
@@ -307,10 +325,8 @@ test('gpt-oss-120b decode on one H200 stays under the measured step time', () =>
   };
   const fixed = step(h200);
   expect(fixed.stepTime).toBeLessThan(measured);
+  // decode at this batch is a weight stream, not a GEMM
   expect(fixed.cost.busy.memory).toBeGreaterThan(fixed.cost.busy.compute);
-  // padding every expert to matmulSatRows made the same step compute-bound
-  // and slower than the engine
-  expect(step({ ...h200, mmaShapes: undefined }).stepTime).toBeGreaterThan(measured);
 });
 
 test('a gemm charges its activation streams to memory', () => {

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -255,32 +255,38 @@ test('thin GEMM dims pay tile padding', () => {
 });
 
 test('a grouped GEMM pads each group to the cheapest MMA instruction', () => {
-  const time = (chip: ChipSpec, groups: number) =>
+  const time = (chip: ChipSpec, m: number, groups?: number) =>
     naiveOpCost(
       {
         kind: 'gemm',
         id: 'g' as OpId,
         label: 'g',
         deps: [],
-        x: tt([256, 128]),
-        w: tt([groups, 128, 128]),
-        out: tt([256, 128]),
+        x: tt([m, 128]),
+        w: tt(groups === undefined ? [128, 128] : [groups, 128, 128]),
+        out: tt([m, 128]),
         dtype: 'bf16',
         groups,
       },
       singleChip(chip),
     ).compute;
+  const dense = time(h100, 256);
   // 256 rows over 111 groups (gpt-oss-120b top-4 at 64 tokens): Hopper
   // pays one m16 mma.sync at 2/3 rate per group, not a 128-row tile
-  expect(time(h100, 111) / time(h100, 1)).toBeCloseTo((111 * 16) / 0.67 / 256, 9);
+  expect(time(h100, 256, 111) / dense).toBeCloseTo((111 * 16) / 0.67 / 256, 9);
+  // one 2-row expert per chip (EP = experts) is still a grouped GEMM: one
+  // m16, not a dense 128-row tile
+  expect(time(h100, 2, 1) / dense).toBeCloseTo(16 / 0.67 / 256, 9);
+  // 32 rows per group fill m16 instructions, so all rows run at 2/3 rate
+  expect(time(h100, 4096, 128) / dense).toBeCloseTo(4096 / 0.67 / 256, 9);
+  // enough rows per group and m64 at full rate wins again
+  expect(time(h100, 8192, 128) / dense).toBeCloseTo(8192 / 256, 9);
   // Blackwell's m64 half-datapath shape is no cheaper than its m128
-  expect(time(CHIPS_BY_ID['b200'], 111) / time(CHIPS_BY_ID['b200'], 1)).toBeCloseTo(
-    (111 * 128) / 256,
-    9,
-  );
+  const b200 = CHIPS_BY_ID['b200'];
+  expect(time(b200, 256, 111) / time(b200, 256)).toBeCloseTo((111 * 128) / 256, 9);
   // without mmaShapes every group pays a saturating matmulSatRows tile
   const noShapes: ChipSpec = { ...h100, mmaShapes: undefined };
-  expect(time(noShapes, 111) / time(noShapes, 1)).toBeCloseTo((111 * 128) / 256, 9);
+  expect(time(noShapes, 256, 111) / time(noShapes, 256)).toBeCloseTo((111 * 128) / 256, 9);
 });
 
 test('gpt-oss-120b decode on one H200 stays under the measured step time', () => {


### PR DESCRIPTION
## Summary

- Add `ChipSpec.mmaShapes`: the chip's MMA row shapes and the fraction of peak each sustains.
- A grouped GEMM pads each active expert to the cheapest shape (`m / rate`) instead of matmulSatRows (unset on every NVIDIA/AMD chip, so `DEFAULT_MATMUL_SAT_ROWS = 128`). Dense GEMMs (groups = 1), N/K padding and chips without mmaShapes are unchanged.- H100/H200: m64 @ 1.0, m16 @ 0.67 ([Luo et al. 2024](https://arxiv.org/abs/2402.13499)). B200/B300/GB200: m128 @ 1.0, m64 @ 0.5 (PTX `tcgen05`), so no change. MI300X/MI325X/MI355X: m16 @ 1.0.

## Why

Compared against SemiAnalysis InferenceX's public single-node rows, HTDYM is a ceiling for LLaMA, R1, Kimi and GLM-5 as intended, but engines beat it by up to 2x on gpt-oss-120b decode. gpt-oss has 128 small experts (top-4), so at 64 concurrent requests each active expert sees ~2 rows, and `tileUtil` bills each one a 128-row tile: 256 real rows become 111 x 128 = 14k and decode flips to compute-bound. Real kernels size the tile from the token count: vLLM's Marlin MoE (what InferenceX runs on H200) picks block 8 here from `[8, 16, 32, 48, 64]` ([marlin_moe.py#L334-L336](https://github.com/vllm-project/vllm/blob/ee3c00bbf47e0ef7e975705cc980b06ee5576bb0/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py#L334-L336)) on an `mma.sync m16` kernel ([marlin_mma.h#L39](https://github.com/vllm-project/vllm/blob/ee3c00bbf47e0ef7e975705cc980b06ee5576bb0/csrc/libtorch_stable/quantization/marlin/marlin_mma.h#L39)); its tuned Triton config for this shape uses `BLOCK_SIZE_M=16` up to 256 tokens and 128 only from 2048 ([E=128,N=2880 config](https://github.com/vllm-project/vllm/blob/ee3c00bbf47e0ef7e975705cc980b06ee5576bb0/vllm/model_executor/layers/fused_moe/configs/E%3D128%2CN%3D2880%2Cdevice_name%3DNVIDIA_H100_80GB_HBM3.json)). 128 is right for dense GEMMs and prefill, wrong as the per-expert floor at decode.

H200 TP=1, 1k/1k, conc 64: HTDYM 37.4 ms/step before (compute-bound), 14.0 ms after (memory-bound); InferenceX TRT-LLM measures 22.5 ms and I got 23.7 ms rerunning their `gptoss_fp4_h200.sh` (vLLM v0.22.0) on a rented Vast.ai H200. gpt-oss violations go 114 -> 48 (H100/H200/MI300X/MI325X to 0), Kimi 4 -> 0, others unchanged. The 48 left are B200 (preset prices bf16 activations/KV, InferenceX runs MXFP8 + fp8 KV) and 3 memory-bound MI355X rows at <= 1.11x, both separate issues. The rates are from the literature, not fitted.

## Tests

In `tests/run.test.ts`:

- `a grouped GEMM pads each group to the cheapest MMA instruction`: Hopper, Blackwell and the no-`mmaShapes` fallback.
- `gpt-oss-120b decode on one H200 stays under the measured step time`: 1k/1k conc 64 decodes under the measured 22.5 ms and memory-bound, and fails both without `mmaShapes`.
