### PR TITLE
Fix per-layer MoE routing estimates and remove unused helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,15 +38,6 @@
     "prettier": "^3.6.2",
     "typescript": "^5.5.3",
     "vite": "^5.3.4",
-    "vitest": "^2.0.4",
-    "prettier": "^3.6.2"
-  },
-  "prettier": {
-    "printWidth": 100,
-    "singleQuote": true,
-    "trailingComma": "all",
-    "semi": true,
-    "arrowParens": "always",
-    "objectWrap": "collapse"
+    "vitest": "^2.0.4"
   }
 }

--- a/src/core/engine/sim/ir/tensors.ts
+++ b/src/core/engine/sim/ir/tensors.ts
@@ -49,7 +49,7 @@ export function typeEq(a: TensorType, b: TensorType): boolean {
   );
 }
 
-export function globalElems(type: TensorType): number {
+function globalElems(type: TensorType): number {
   return type.shape.reduce((acc, shape) => acc * shape, 1);
 }
 

--- a/src/core/engine/sim/lowering/lower.ts
+++ b/src/core/engine/sim/lowering/lower.ts
@@ -1,4 +1,3 @@
-import { expertReadFraction } from '../../../model/utils';
 import { ModelSpec } from '../../../model/models';
 import { DTYPE_BYTES } from '../../../model/dtype';
 import {
@@ -174,7 +173,6 @@ export function lowerStage(args: LowerArgs, stage: Stage): Segment<LoweredOp>[] 
         weights: precision.weights,
         acts,
         residual: precision.residual,
-        activatedFrac: expertReadFraction(model, tokensTotal),
       });
 
       residual = trace.expect(residual, residualT); // [B_dpa, D]

--- a/src/core/engine/sim/lowering/moe.ts
+++ b/src/core/engine/sim/lowering/moe.ts
@@ -15,7 +15,6 @@ export interface MoeArgs {
   acts: CategoryDtypes;
   // width of the residual stream the block's output reductions land in
   residual: Dtype;
-  activatedFrac: number;
 }
 
 export function lowerMoe(trace: TraceBuilder, x: Val, args: MoeArgs): Val {
@@ -25,6 +24,8 @@ export function lowerMoe(trace: TraceBuilder, x: Val, args: MoeArgs): Val {
   const ep = roleSize(mesh, 'EP');
   const d = x.type.shape[1];
   const inner = mlp.latentDim || d;
+  // Under uniform routing, an expert is untouched only if every token misses it.
+  const activatedFrac = 1 - Math.pow(1 - mlp.topK / mlp.experts, args.tokensTotal);
 
   // the small [D, E] router replicates on every rank
   // so each can pick global top-k without gathering logits
@@ -98,11 +99,11 @@ export function lowerMoe(trace: TraceBuilder, x: Val, args: MoeArgs): Val {
       variant: mlp.variant,
       weights: args.weights.routedExperts,
       dtype: args.acts.routedExperts,
-      loadFraction: args.activatedFrac,
+      loadFraction: activatedFrac,
       experts: {
         count: mlp.experts,
         epSharding: roles['EP'],
-        activeGroups: (mlp.experts * args.activatedFrac) / ep,
+        activeGroups: (mlp.experts * activatedFrac) / ep,
       },
       extraDeps: [router],
     }); // [(B*topK)_ep, D] -> [(B*topK)_ep, D] {U_etp}
@@ -154,11 +155,11 @@ export function lowerMoe(trace: TraceBuilder, x: Val, args: MoeArgs): Val {
       variant: mlp.variant,
       weights: args.weights.routedExperts,
       dtype: args.acts.routedExperts,
-      loadFraction: args.activatedFrac,
+      loadFraction: activatedFrac,
       experts: {
         count: mlp.experts,
         epSharding: roles['EP'],
-        activeGroups: (mlp.experts * args.activatedFrac) / ep,
+        activeGroups: (mlp.experts * activatedFrac) / ep,
       },
     }); // [(B * topK)_ep, L] -> [(B * topK)_ep, L] {U_etp}
 

--- a/src/core/hardware/topology.ts
+++ b/src/core/hardware/topology.ts
@@ -84,10 +84,6 @@ export interface MeshDim {
   stride: number;
 }
 
-export function reachableChips(ic: InterconnectSpec): number {
-  return ic.domainSize * (ic.scaleOut?.maxNodes ?? 1);
-}
-
 // Resolve the machine a deployment occupies into named physical axes.
 export function deployedAxes(
   ic: InterconnectSpec,

--- a/src/core/model/block/index.ts
+++ b/src/core/model/block/index.ts
@@ -179,7 +179,7 @@ export function blockAttnFlopsDecodeParts(b: BlockSpec, ctx: number): AttnFlopPa
   };
 }
 
-export function blockAttnFlopsDecode(b: BlockSpec, ctx: number): number {
+function blockAttnFlopsDecode(b: BlockSpec, ctx: number): number {
   const p = blockAttnFlopsDecodeParts(b, ctx);
   return p.core + p.indexer;
 }
@@ -225,11 +225,6 @@ export function blockAttnFlopsPrefillParts(b: BlockSpec, T: number): AttnFlopPar
     core: 2 * (localPairs + longPairs) * N * (H + H),
     indexer: a.indexer ? 2 * indexPairs * a.indexer.heads * a.indexer.headDim : 0,
   };
-}
-
-export function blockAttnFlopsPrefill(b: BlockSpec, T: number): number {
-  const p = blockAttnFlopsPrefillParts(b, T);
-  return p.core + p.indexer;
 }
 
 // KV bytes one sequence stores for one block ('store') or one decode step

--- a/src/core/model/utils.ts
+++ b/src/core/model/utils.ts
@@ -1,8 +1,6 @@
 import {
   BlockSpec,
-  blockAttnFlopsDecode,
   blockAttnFlopsDecodeParts,
-  blockAttnFlopsPrefill,
   blockAttnFlopsPrefillParts,
   blockAttnParams,
   blockDenseMlpParams,
@@ -33,14 +31,6 @@ export function layerCount(m: ModelSpec): number {
   return m.blocks.reduce((s, g) => s + g.repeat * g.pattern.reduce((t, r) => t + r.count, 0), 0);
 }
 
-// Parameters of the ROUTED experts across all MoE layers: the weight bytes
-// whose per-step read traffic depends on the batch (only the experts the
-// batch routes to are touched). Shared experts and routers are always read,
-// so they count with the dense weights instead.
-export function routedExpertParams(m: ModelSpec): number {
-  return sumBlocks(m, (b) => blockRoutedExpertParams(m, b).total);
-}
-
 // Total weight bytes at the model's native per-component precision. This is
 // the checkpoint footprint modulo block-scale overhead, so published sizes
 // anchor it directly.
@@ -60,17 +50,6 @@ export function weightBytesTotal(m: ModelSpec): number {
   return blockBytes + embeddingCopies * m.vocab * m.modelDim * B(w.embeddings);
 }
 
-// Expected fraction of routed-expert weight bytes read while processing
-// tokens tokens in one step: each token picks topK of E experts, so an
-// expert is untouched w.p. (1 - k/E)^tokens under uniform routing. 1 for
-// dense models.
-export function expertReadFraction(m: ModelSpec, tokens: number): number {
-  for (const b of uniqueBlocks(m)) {
-    if (b.mlp.kind === 'moe') return 1 - Math.pow(1 - b.mlp.topK / b.mlp.experts, tokens);
-  }
-  return 1;
-}
-
 function totalMlpParams(m: ModelSpec): number {
   return sumBlocks(
     m,
@@ -83,7 +62,7 @@ function totalMlpParams(m: ModelSpec): number {
   );
 }
 
-export function totalAttnParams(m: ModelSpec): number {
+function totalAttnParams(m: ModelSpec): number {
   return sumBlocks(m, (b) => blockAttnParams(m, b).total);
 }
 
@@ -117,10 +96,6 @@ export function activeParams(m: ModelSpec): number {
 // routed experts below its attention, and the two then land on different
 // peaks, so a single FLOP total has no one rate to be divided by.
 export type FlopsByWidth = Map<Dtype, number>;
-
-export function totalFlops(byWidth: FlopsByWidth): number {
-  return [...byWidth.values()].reduce((a, b) => a + b, 0);
-}
 
 function addFlops(out: FlopsByWidth, d: Dtype, flops: number): void {
   if (flops > 0) out.set(d, (out.get(d) ?? 0) + flops);
@@ -176,26 +151,6 @@ export function flopsPerPrefillToken(m: ModelSpec, T: number): FlopsByWidth {
   return out;
 }
 
-// Dot-product attention FLOPs to prefill one sequence of T tokens, whole
-// model. Per layer, attending over p (query, key) pairs costs
-// 2*p*N*(H_qk + H_v). Causal full attention gives p = T^2/2. A sliding window
-// caps each query's span at W, so p = W^2/2 + (T-W)*W for T > W. DSA caps the
-// main attention's span at topk the same way, but its indexer still scores
-// every prior token (quadratic).
-export function attnFlopsPrefill(m: ModelSpec, T: number): number {
-  return sumBlocks(m, (b) => blockAttnFlopsPrefill(b, T));
-}
-
-// Dot-product attention FLOPs to decode ONE token of ONE sequence with ctx
-// tokens of context, whole model. Local layers only attend over the window.
-// MLA uses the "absorbed" decode form: attention runs directly in the latent,
-// so every query head attends over (d_c + d_rope)-dim keys and d_c-dim
-// values. DSA caps the main attention at topk tokens, but its indexer still
-// scores all ctx.
-export function attnFlopsPerDecodeToken(m: ModelSpec, ctx: number): number {
-  return sumBlocks(m, (b) => blockAttnFlopsDecode(b, ctx));
-}
-
 // Total KV cache bytes for one sequence of length len, unsharded.
 // access: bytes resident in HBM ('store') or bytes one decode step reads
 // ('read'). They differ only under DSA, which caps latent reads at topk
@@ -218,12 +173,6 @@ export function moeExperts(m: ModelSpec): number {
   let e = 0;
   for (const b of uniqueBlocks(m)) if (b.mlp.kind === 'moe') e = Math.max(e, b.mlp.experts);
   return e;
-}
-
-// Representative topK from the first MoE block (uniform MoE stacks).
-export function moeTopK(m: ModelSpec): number {
-  for (const b of uniqueBlocks(m)) if (b.mlp.kind === 'moe') return b.mlp.topK;
-  return 0;
 }
 
 export function hasMlaLayers(m: ModelSpec): boolean {

--- a/src/ui/metrics.ts
+++ b/src/ui/metrics.ts
@@ -244,7 +244,7 @@ const METRICS: MetricDef[] = [
  * tokens plus S decode tokens, served at the machine's aggregate per-phase
  * rates. Null until both phases are evaluated.
  */
-export function machineRps(r: UiResult): number | null {
+function machineRps(r: UiResult): number | null {
   const pf = r.prefill;
   const dec = r.decode;
   if (!pf || !dec) return null;

--- a/tests/lowering.fuzz.test.ts
+++ b/tests/lowering.fuzz.test.ts
@@ -14,13 +14,7 @@ import { ModelSpec } from '../src/core/model/models';
 import { gqa, linearAttn, mla } from '../src/core/model/block/attn';
 import { denseMlp, moeMlp } from '../src/core/model/block/mlp';
 import { DTYPE_BYTES, type Dtype } from '../src/core/model/dtype';
-import {
-  expertReadFraction,
-  flopsPerPrefillToken,
-  kvBytesPerSeq,
-  routedExpertParams,
-  weightBytesTotal,
-} from '../src/core/model/utils';
+import { flopsPerPrefillToken, kvBytesPerSeq, weightBytesTotal } from '../src/core/model/utils';
 
 // The closed forms in model/utils compute FLOPs and bytes algebraically
 // from the spec, while lowering builds sharded tensors op by op. They
@@ -172,8 +166,7 @@ fuzzTest('stage partitioning preserves the flattened layer stack', (rand) => {
 
 fuzzTest('single-chip prefill conserves the closed-form FLOPs and bytes', (rand) => {
   const { model } = generator(rand);
-  // large and tile-aligned so utilization is exactly 1 and virtually
-  // every expert is activated
+  // Large enough to activate virtually every expert.
   const T = 16384;
 
   const m = model();
@@ -207,20 +200,13 @@ fuzzTest('single-chip prefill conserves the closed-form FLOPs and bytes', (rand)
     0,
   );
 
-  // the embedding gather is not lowered, and routed experts stream only
-  // the activated fraction
+  // At this token count, virtually all expert weights are read.
+  // The embedding gather is not lowered.
   const emb = m.tiedEmbeddings
     ? 0
     : m.vocab * m.modelDim * DTYPE_BYTES[m.precision.weights.embeddings];
-  const inactive =
-    routedExpertParams(m) *
-    DTYPE_BYTES[m.precision.weights.routedExperts] *
-    (1 - expertReadFraction(m, T));
   const bytes =
-    weightBytesTotal(m) -
-    emb -
-    inactive +
-    kvBytesPerSeq(m, DTYPE_BYTES[m.precision.kv], T, 'store');
+    weightBytesTotal(m) - emb + kvBytesPerSeq(m, DTYPE_BYTES[m.precision.kv], T, 'store');
   expect((r.cost.busy.memory - acts / hbm) / (bytes / hbm)).toBeCloseTo(1, 9);
 });
 

--- a/tests/presets.conserve.test.ts
+++ b/tests/presets.conserve.test.ts
@@ -8,13 +8,7 @@ import { matmulSeconds } from '../src/core/engine/roofline';
 import { PhysAxis } from '../src/core/hardware/topology';
 import { MODEL_PRESETS } from '../src/core/model/models';
 import { DTYPE_BYTES } from '../src/core/model/dtype';
-import {
-  expertReadFraction,
-  flopsPerPrefillToken,
-  kvBytesPerSeq,
-  routedExpertParams,
-  weightBytesTotal,
-} from '../src/core/model/utils';
+import { flopsPerPrefillToken, kvBytesPerSeq, weightBytesTotal } from '../src/core/model/utils';
 
 const backend = makeNaiveOpCostSumBackend({ memoryOverlap: 0, commsOverlap: 0 });
 const chip: ChipSpec = {
@@ -48,6 +42,7 @@ function singleChip(): Deployment {
 // only automated check that the trace and the closed forms in model/utils
 // still agree on an architecture either one of them could get wrong alone.
 test('every preset conserves the closed-form FLOPs and bytes', () => {
+  // Large enough to activate virtually every expert; run.test.ts covers small batches.
   const T = 16384;
   for (const m of MODEL_PRESETS) {
     const r = evaluatePrefill(
@@ -76,15 +71,8 @@ test('every preset conserves the closed-form FLOPs and bytes', () => {
     const emb = m.tiedEmbeddings
       ? 0
       : m.vocab * m.modelDim * DTYPE_BYTES[m.precision.weights.embeddings];
-    const inactive =
-      routedExpertParams(m) *
-      DTYPE_BYTES[m.precision.weights.routedExperts] *
-      (1 - expertReadFraction(m, T));
     const bytes =
-      weightBytesTotal(m) -
-      emb -
-      inactive +
-      kvBytesPerSeq(m, DTYPE_BYTES[m.precision.kv], T, 'store');
+      weightBytesTotal(m) - emb + kvBytesPerSeq(m, DTYPE_BYTES[m.precision.kv], T, 'store');
     const fl = r.cost.busy.compute / ideal,
       by = (r.cost.busy.memory - acts / hbm) / (bytes / hbm);
     expect(fl).toBeCloseTo(1, 9);

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -194,6 +194,41 @@ test('single-chip MoE prefill matches the closed-form roofline', () => {
   expect(prefillCompute(model, T) / ideal).toBeCloseTo(1, 6);
 });
 
+test('mixed MoE layers use their own routing fraction', () => {
+  const base = MODEL_PRESETS.find((m) => m.name === 'LLaMA 3 8B')!;
+  const model: ModelSpec = {
+    ...base,
+    blocks: [
+      {
+        repeat: 1,
+        pattern: [4, 8].map((topK, i) => ({
+          count: 1,
+          block: {
+            attn: base.blocks[0].pattern[0].block.attn,
+            mlp: moeMlp({ experts: 64, topK, expertDim: 128 * (i + 1) }),
+          },
+        })),
+      },
+    ],
+  };
+  const r = evaluateDecodeAtBatch(
+    { model, deployment: singleChip(), workload: { prefillLen: 1, generateLen: 0 } },
+    1,
+    1,
+    { costBackend: backend },
+  );
+  if (!r.ok) throw new Error('eval failed');
+  const ops = r.perStageTrace[0].flatMap((s) => s.ops);
+  expect(
+    ops.flatMap((op) => (op.kind === 'gemm' && op.label === 'experts-in' ? [op.groups] : [])),
+  ).toEqual([4, 8]);
+  expect(
+    ops.flatMap((op) =>
+      op.kind === 'weight-load' && op.label === 'experts-in-weight' ? [op.loadFraction] : [],
+    ),
+  ).toEqual([1 / 16, 1 / 8]);
+});
+
 test('single-chip dense prefill memory matches weights plus KV writes', () => {
   const model = MODEL_PRESETS.find((m) => m.name === 'LLaMA 3 8B')!;
   const T = 512;


### PR DESCRIPTION
MoE lowering used the first MoE layer’s routing fraction for every layer. Compute the fraction from each layer’s own expert count and top-k instead. For a one-token batch, two layers with 64 experts and top-k values of 4 and 8 now charge 4 and 8 active experts, rather than 4 for both.

Remove the obsolete model-wide routing helpers and other unused functions, make helpers private where they are only used within their module, and remove duplicate package configuration. The large-batch conservation tests already activate all experts at floating-point precision, so they no longer need the removed routing helpers.

This is the independent MoE fix and cleanup split out of the work on #2. Matrix-padding behavior is unchanged.

Validation: all 87 tests pass, including the mixed-layer regression and search benchmarks; production build and repository-wide formatting checks pass.
