### PR TITLE
Model GEMM padding with dtype-specific hardware shapes

### DIFF
--- a/src/core/engine/sim/cost/helpers/naiveOpCost.ts
+++ b/src/core/engine/sim/cost/helpers/naiveOpCost.ts
@@ -1,27 +1,35 @@
 import { collectiveCost } from './collectives';
 import { ExpandedOp } from '../../ir/ops';
 import { localElems, shardWays } from '../../ir/tensors';
-import { DEFAULT_MATMUL_SAT_ROWS, peakFlops } from '../../../../hardware/chips';
+import { peakFlops } from '../../../../hardware/chips';
+import type { MmaShape } from '../../../../hardware/mma';
 import type { HardwareResource } from '../../../surface/api';
 import type { Deployment } from '../../../surface/deploy';
 import { DTYPE_BYTES, type Dtype } from '../../../../model/dtype';
 
 export type OpCost = Record<HardwareResource, number>;
 
-// Padded-tile utilization: the matmul array's tile is `tile` wide on
-// every edge (a 128x128 MXU, 128-row tensor-core macro-tiles), so all
-// three GEMM dims pad up to it. A thin N or K shard (deep TP/ETP
-// slicing a projection) idles the array's columns or depth exactly like
-// a short M idles its rows. Grouped GEMMs pad rows per activated group
-// (multinomial token counts smooth the per-group ceiling, keep the
-// floor: every activated group pads to one tile).
-function tileUtil(m: number, n: number, k: number, groups: number, tile: number): number {
-  // tile 1 = no tiling at all (fractional dims, e.g. MLA's equivalent
-  // columns, must not round)
-  if (tile <= 1 || m <= 0 || n <= 0 || k <= 0) return 1;
-  const pad = (d: number) => tile * Math.ceil(d / tile);
-  const rows = groups <= 1 ? pad(m) : Math.max(m, groups * tile);
-  return (m * n * k) / (rows * pad(n) * pad(k));
+// Padded work divided by the path's relative rate, expressed as equivalent FLOPs
+// at full rate. The caller divides by the chip's sustained FLOP/s to get seconds.
+function adjustedFlops(
+  shapes: readonly MmaShape[],
+  m: number,
+  n: number,
+  k: number,
+  groups = 1,
+): number {
+  if (m <= 0 || n <= 0 || k <= 0) return 0;
+  // Unit tiles disable padding, including for fractional analytical shapes.
+  const pad = (d: number, tile: number) => (tile <= 1 ? d : tile * Math.ceil(d / tile));
+  return Math.min(
+    ...shapes.map((s) => {
+      // M counts total rows across groups. Round that total, then require at least
+      // one tile per active group. Individual group sizes are unknown, so this
+      // can miss partial-tile waste. One group is identical to a dense GEMM.
+      const rows = s.m <= 1 ? m : Math.max(pad(m, s.m), groups * s.m);
+      return (2 * rows * pad(n, s.n) * pad(k, s.k)) / s.rate;
+    }),
+  );
 }
 
 export function naiveOpCost(op: ExpandedOp, deployment: Deployment): OpCost {
@@ -30,8 +38,8 @@ export function naiveOpCost(op: ExpandedOp, deployment: Deployment): OpCost {
 
   const zero: OpCost = { compute: 0, memory: 0, comms: 0 };
 
-  // the ! holds because runnableOn resolved every op dtype to a unit this chip has
-  const rate = (d: Dtype) => peakFlops(chip, d)! * chip.realizableFlopsFrac;
+  // The ! holds because runnableOn resolved every op dtype to a unit this chip has.
+  const flopsPerSecond = (d: Dtype) => peakFlops(chip, d)! * chip.realizableFlopsFrac;
   const hbm = chip.hbmBandwidth * chip.realizableHbmBwFrac;
 
   switch (op.kind) {
@@ -41,22 +49,17 @@ export function naiveOpCost(op: ExpandedOp, deployment: Deployment): OpCost {
       const mLocal = m / shardWays(op.x.sharding[0], dims);
       const kLocal = k / shardWays(op.x.sharding[1], dims);
       const nLocal = op.w.shape[last] / shardWays(op.w.sharding[last], dims);
-      const util = tileUtil(
-        mLocal,
-        nLocal,
-        kLocal,
-        op.groups ?? 1,
-        chip.matmulSatRows ?? DEFAULT_MATMUL_SAT_ROWS,
-      );
       return {
-        compute: (2 * mLocal * kLocal * nLocal) / (rate(op.dtype) * util),
+        compute:
+          adjustedFlops(chip.mmaShapes[op.dtype], mLocal, nLocal, kLocal, op.groups) /
+          flopsPerSecond(op.dtype),
         memory: (mLocal * (kLocal + nLocal) * DTYPE_BYTES[op.dtype]) / hbm,
         comms: 0,
       };
     }
     case 'attention':
       return {
-        compute: op.flops / rate(op.dtype),
+        compute: op.flops / flopsPerSecond(op.dtype),
         memory: (op.kvReadBytes + op.kvWriteBytes) / hbm,
         comms: 0,
       };

--- a/src/core/engine/sim/ir/ops.ts
+++ b/src/core/engine/sim/ir/ops.ts
@@ -26,9 +26,9 @@ export interface GemmOp extends OpBase {
   // format this matmul's operands arrive in, which picks the chip's peak for
   // it and sizes the rows it streams
   dtype: Dtype;
-  // independent identical matmuls batched in one launch (grouped GEMM:
-  // activated experts). Tile padding is per group. FLOPs already count all
-  // m rows, so groups does not multiply them.
+  // Estimated active groups (experts) per device, sharing K and N. The input's M
+  // counts all routed rows before sharding; individual group sizes are not
+  // represented. The cost backend estimates their padding from this count.
   groups?: number;
 }
 

--- a/src/core/hardware/chips.ts
+++ b/src/core/hardware/chips.ts
@@ -1,20 +1,34 @@
 import type { Dtype } from '../model/dtype';
 import { InterconnectSpec, SliceTopology } from './topology';
+import {
+  type MmaShapes,
+  AMPERE_MMA,
+  ADA_MMA,
+  HOPPER_MMA,
+  BLACKWELL_MMA,
+  BLACKWELL_ULTRA_MMA,
+  RUBIN_MMA,
+  SM120_MMA,
+  CDNA3_MMA,
+  CDNA4_MMA,
+  GAUDI_MMA,
+  NEURON_V2_MMA,
+  NEURON_V3_MMA,
+  TPU_V5P_MMA,
+  TPU_V6E_MMA,
+  TPU_V7X_MMA,
+} from './mma';
 
 export interface ChipSpec {
   id: string;
   name: string;
   vendor: string;
 
-  // What a chip supports for a give format: a number is a peak dense matmul rate,
-  // the chip has a unit and multiplies the format as stored, and 'kernel-widened'
-  // means there is a known kernel which can unpack a tensor of this format
-  // on its way from HBM into the matmul units into a wider format, meaning
-  // it can be used to speed up weight loads, just not matmul flops/sec.
-  // If there is no entry for a dtype, we still assume a kernel could exist
-  // and price accordingly, but we'll throw a warning that it needs to be written.
-  // We assume these kernels don't add any overhead, which is not a perfect assumption,
-  // but probably close enough in practice, it shouldn't be too hard to pipeline.
+  // Native dense matmul peak in FLOP/s, or 'kernel-widened' when a known kernel
+  // can unpack stored weights into a supported format. Missing entries also
+  // assume a widening kernel, but trigger a warning that one is needed.
+  // Stored weight dtype sets weight traffic; resolved compute dtype sets throughput.
+  // Unpacking/conversion overhead is omitted.
   //
   // bf16 must be a rate: it is the floor every substitution ladder
   // ends at, which is what lets runsAs always land somewhere.
@@ -35,21 +49,15 @@ export interface ChipSpec {
   tdp?: number;
   // Fraction of the datasheet matmul rate a well-tuned, well-shaped GEMM
   // sustains (sustained clocks, kernel quality). Derates compute pricing
-  // only; shape-dependent padding is priced separately via matmulSatRows.
+  // only; padding and relative instruction throughput are priced via mmaShapes.
   realizableFlopsFrac: number;
   // Fraction of hbmBandwidth a well-tuned streaming kernel sustains;
   // derates every memory price.
   realizableHbmBwFrac: number;
-  // Edge of the matmul array's tile: every GEMM dim (M, N and K) pads up
-  // to it, so thin shards run at padded-volume utilization (a 64-deep
-  // contraction on a 128x128 MXU idles half the array).
-  // DEFAULT_MATMUL_SAT_ROWS = 128, since TPU MXUs are 128x128 and
-  // H100-class GEMMs want >=128-row tiles.
-  matmulSatRows?: number;
+  // Arithmetic paths by resolved compute dtype, shared by dense/grouped GEMMs.
+  // Uncharacterized paths use the explicit APPROXIMATE_MMA table.
+  mmaShapes: MmaShapes;
 }
-
-// Fallback ChipSpec.matmulSatRows, see that field's doc.
-export const DEFAULT_MATMUL_SAT_ROWS = 128;
 
 // What a format degrades to when a chip has no matmul unit for it: each names
 // the next format its data can be unpacked into, and following the chain gives
@@ -112,6 +120,7 @@ const V7X_SLICES = slices([
 export const CHIPS: ChipSpec[] = [
   {
     id: 'a100-sxm',
+    mmaShapes: AMPERE_MMA,
     name: 'A100 SXM',
     vendor: 'NVIDIA',
     formats: {
@@ -142,6 +151,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'h100-sxm',
+    mmaShapes: HOPPER_MMA,
     name: 'H100 SXM',
     vendor: 'NVIDIA',
     // int8 shares the fp8 unit and rate. No int4 unit: Hopper dropped it.
@@ -174,6 +184,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'h200-sxm',
+    mmaShapes: HOPPER_MMA,
     name: 'H200 SXM',
     vendor: 'NVIDIA',
     // same GH100 die: units and kernel story as H100 above
@@ -204,6 +215,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'b200',
+    mmaShapes: BLACKWELL_MMA,
     name: 'B200 SXM',
     vendor: 'NVIDIA',
     formats: {
@@ -235,6 +247,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'gb200-nvl72',
+    mmaShapes: BLACKWELL_MMA,
     name: 'GB200 NVL72',
     vendor: 'NVIDIA',
     // same units and int4 kernel story as the B200 entry above
@@ -264,6 +277,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'b300',
+    mmaShapes: BLACKWELL_ULTRA_MMA,
     name: 'B300 SXM',
     vendor: 'NVIDIA',
     // Blackwell Ultra's uplift is FP4-only. NVIDIA quotes DGX B300 at 108
@@ -301,6 +315,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'vr100-nvl72',
+    mmaShapes: RUBIN_MMA,
     name: 'VR100 NVL72',
     vendor: 'NVIDIA',
     formats: {
@@ -327,6 +342,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'rtx-pro-6000',
+    mmaShapes: SM120_MMA,
     name: 'RTX PRO 6000',
     vendor: 'NVIDIA',
     formats: {
@@ -361,6 +377,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'rtx-5090',
+    mmaShapes: SM120_MMA,
     name: 'RTX 5090',
     vendor: 'NVIDIA',
     formats: {
@@ -396,6 +413,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'rtx-4090',
+    mmaShapes: ADA_MMA,
     name: 'RTX 4090',
     vendor: 'NVIDIA',
     formats: {
@@ -428,6 +446,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'mi300x',
+    mmaShapes: CDNA3_MMA,
     name: 'MI300X',
     vendor: 'AMD',
     formats: {
@@ -460,6 +479,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'mi325x',
+    mmaShapes: CDNA3_MMA,
     name: 'MI325X',
     vendor: 'AMD',
     formats: {
@@ -488,6 +508,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'mi355x',
+    mmaShapes: CDNA4_MMA,
     name: 'MI355X',
     vendor: 'AMD',
     formats: {
@@ -519,6 +540,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'gaudi2',
+    mmaShapes: GAUDI_MMA,
     name: 'Gaudi 2',
     vendor: 'Intel',
     formats: { bf16: 432e12, fp8: 865e12, int8: 'kernel-widened' },
@@ -540,6 +562,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'gaudi3',
+    mmaShapes: GAUDI_MMA,
     name: 'Gaudi 3',
     vendor: 'Intel',
     formats: { bf16: 1835e12, fp8: 1835e12, int8: 'kernel-widened' },
@@ -562,6 +585,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'inferentia2',
+    mmaShapes: NEURON_V2_MMA,
     name: 'Inferentia2',
     vendor: 'AWS',
     formats: { bf16: 190e12, fp8: 190e12, int8: 380e12 },
@@ -587,6 +611,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'trainium1',
+    mmaShapes: NEURON_V2_MMA,
     name: 'Trainium1',
     vendor: 'AWS',
     formats: { bf16: 190e12, fp8: 190e12, int8: 380e12 },
@@ -613,6 +638,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'trainium2',
+    mmaShapes: NEURON_V3_MMA,
     name: 'Trainium2',
     vendor: 'AWS',
     formats: { bf16: 668.75e12, fp8: 1300e12, int8: 'kernel-widened' },
@@ -638,6 +664,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'tpu-v5p',
+    mmaShapes: TPU_V5P_MMA,
     name: 'TPU v5p',
     vendor: 'Google',
     formats: { bf16: 459e12, int8: 918e12, int4: 1836e12, fp8: 'kernel-widened' },
@@ -662,6 +689,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'tpu-v6e',
+    mmaShapes: TPU_V6E_MMA,
     name: 'TPU v6e',
     vendor: 'Google',
     formats: { bf16: 918e12, int8: 1836e12, int4: 3672e12, fp8: 'kernel-widened' },
@@ -684,6 +712,7 @@ export const CHIPS: ChipSpec[] = [
   },
   {
     id: 'tpu-v7x',
+    mmaShapes: TPU_V7X_MMA,
     name: 'TPU v7x',
     vendor: 'Google',
     formats: {

--- a/src/core/hardware/mma.ts
+++ b/src/core/hardware/mma.ts
@@ -1,0 +1,215 @@
+import type { Dtype } from '../model/dtype';
+
+// Small GEMMs can use smaller tiles, sometimes at reduced throughput. Padding
+// every dimension to 128 can therefore overestimate their compute time.
+//
+// For C[M,N] = A[M,K] × B[K,N], each dtype lists alternative instruction shapes
+// or effective throughput tiles, including transposed paths. Dense and grouped
+// GEMMs round M/N/K up for each candidate, divide padded work by its relative
+// rate, and choose the cheapest. realizableFlopsFrac applies separately.
+// The grouped-row approximation is documented in adjustedFlops in naiveOpCost.ts.
+//
+// H100, B200 and B300 floating-point rates come from instruction microbenchmarks.
+// Other entries use documented shapes or throughput approximations, with sources
+// and assumptions beside the tables. Uncharacterized paths use the 128³ fallback.
+// Only arithmetic is estimated here: layout conversion, unpacking and kernel
+// launch overhead are omitted. HBM traffic uses unpadded tensor sizes separately.
+export interface MmaShape {
+  // A dimension of 1 skips padding on that axis.
+  m: number;
+  n: number;
+  k: number;
+  // Fraction of the resolved dtype's peak, before realizableFlopsFrac.
+  // A rate of .5 doubles the compute time for the same padded work.
+  rate: number;
+}
+
+// ChipSpec.formats determines dtype support; these tables only price arithmetic.
+export type MmaShapes = Record<Dtype, readonly MmaShape[]>;
+
+// Fallback: pad each axis to 128 at full rate until a better estimate is available.
+// This is a cost approximation, not a hardware instruction shape.
+const APPROXIMATE_CUBE: readonly MmaShape[] = [{ m: 128, n: 128, k: 128, rate: 1 }];
+export const APPROXIMATE_MMA: MmaShapes = {
+  bf16: APPROXIMATE_CUBE,
+  fp8: APPROXIMATE_CUBE,
+  fp4: APPROXIMATE_CUBE,
+  mxfp8: APPROXIMATE_CUBE,
+  mxfp4: APPROXIMATE_CUBE,
+  nvfp4: APPROXIMATE_CUBE,
+  int8: APPROXIMATE_CUBE,
+  int4: APPROXIMATE_CUBE,
+};
+
+// C = AB or Cᵀ = BᵀAᵀ; swapped paths also exchange operand scale tensors.
+// Loading/repacking costs are outside this arithmetic model.
+const orientations = (m: number, n: number, k: number, rate = 1): MmaShape[] => [
+  { m, n, k, rate },
+  { m: n, n: m, k, rate },
+];
+
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-instructions-mma
+const warp = (k: number, rate = 1): MmaShape[] => orientations(16, 8, k, rate);
+
+export const AMPERE_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: warp(16),
+  int8: warp(32),
+  int4: warp(64),
+};
+export const ADA_MMA: MmaShapes = { ...AMPERE_MMA, fp8: warp(32) };
+
+// H100 instruction measurements (CUDA 12.8, 2026-09-06): register-A/shared-B
+// WGMMA at N32 reaches ~97-99% of wide throughput, rounded to 1; N16 ~.6.
+// BF16 warp MMA reaches ~.67. Operand movement/conversion costs are omitted.
+const hopper = (k: number): MmaShape[] => orientations(64, 32, k);
+// INT8 retains the H800 paper's estimate; it was not remeasured here.
+// https://arxiv.org/html/2501.12084v1 (Tables VII-XI)
+export const HOPPER_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: [...warp(16, 0.67), ...hopper(16)],
+  fp8: [
+    ...warp(16, 0.335), // Explicit BF16 widening: .67 × .5 of FP8 peak.
+    ...orientations(64, 16, 32, 0.6),
+    ...hopper(32),
+  ],
+  int8: [...warp(32, 0.67), { m: 64, n: 64, k: 32, rate: 1 }],
+};
+
+// B200/B300 instruction microbenchmarks, CUDA 12.8/13.1, CUTLASS 4.2.1 (2026-09-06).
+// Rounded rates relative to wide tcgen05 throughput. One-CTA block-scaled
+// instructions require M=128; BF16/FP8 also support M=64. These are native
+// dimensions, before adding transposed paths. N<32 paths are omitted because
+// they add little benefit to this padding model.
+// FP4 uses block scaling, with unit scales for the unscaled format.
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-matrix-shape
+const blackwellM128 = (k: number, rate = 1): MmaShape[] => [
+  { m: 128, n: 128, k, rate },
+  ...orientations(128, 64, k, (2 / 3) * rate),
+  ...orientations(128, 32, k, 0.4 * rate),
+];
+const blackwellM64 = (k: number): MmaShape[] => [
+  { m: 64, n: 64, k, rate: 0.5 },
+  ...orientations(64, 32, k, 1 / 3),
+];
+export const BLACKWELL_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: [...warp(16, 0.25), ...blackwellM128(16), ...blackwellM64(16)],
+  // FP8 explicitly widens to BF16 for the warp path: .25 × .5 of FP8 peak.
+  // Conversion cost is omitted; this is not a native FP8 warp instruction rate.
+  fp8: [...warp(16, 0.125), ...blackwellM128(32), ...blackwellM64(32)],
+  int8: [{ m: 128, n: 128, k: 32, rate: 1 }], // Unmeasured wide tcgen05 estimate.
+  mxfp8: blackwellM128(32),
+  fp4: blackwellM128(64),
+  mxfp4: blackwellM128(64),
+  nvfp4: blackwellM128(64),
+};
+// B300 reaches its higher FP4 peak with a two-CTA 256x256x96 instruction.
+// Smaller tiles retain B200 throughput (2/3 of B300's FP4 peak); the
+// 128x256x96 path reaches 8/9. Keep K64 as well to avoid unnecessary K padding.
+const blackwellUltraFp4: MmaShape[] = [
+  ...blackwellM128(64, 2 / 3),
+  ...blackwellM128(96, 2 / 3),
+  ...orientations(128, 256, 96, 8 / 9),
+  { m: 256, n: 256, k: 96, rate: 1 },
+];
+export const BLACKWELL_ULTRA_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: BLACKWELL_MMA.bf16,
+  fp8: BLACKWELL_MMA.fp8,
+  mxfp8: BLACKWELL_MMA.mxfp8,
+  fp4: blackwellUltraFp4,
+  mxfp4: blackwellUltraFp4,
+  nvfp4: blackwellUltraFp4,
+};
+
+// Rubin SM107: documented wide instruction shapes, with an unmeasured full-rate
+// assumption. Smaller and older paths are omitted until their rates are measured.
+// FP8 K64 requires M128 for one CTA; FP4 uses unit scales for the unscaled format.
+// https://github.com/NVIDIA/cutlass/blob/59e3a3338d516ca6ce0e073af8da65289678a35c/examples/python/CuTeDSL/cute/rubin/kernel/dense_gemm/dense_gemm_persistent.py
+// https://github.com/NVIDIA/cutlass/blob/59e3a3338d516ca6ce0e073af8da65289678a35c/include/cute/atom/mma_traits_sm107.hpp
+export const RUBIN_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: [{ m: 128, n: 128, k: 16, rate: 1 }],
+  fp8: [{ m: 128, n: 128, k: 64, rate: 1 }],
+  mxfp8: [{ m: 128, n: 128, k: 64, rate: 1 }],
+  fp4: [{ m: 128, n: 128, k: 128, rate: 1 }],
+  mxfp4: [{ m: 128, n: 128, k: 128, rate: 1 }],
+  nvfp4: [{ m: 128, n: 128, k: 128, rate: 1 }],
+};
+
+// SM120 uses warp MMA, including K32/K64 block-scaled forms (unit scales for FP4).
+// https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/cute_dsl_api/cute_nvgpu_warp.html
+export const SM120_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: warp(16),
+  fp8: warp(32),
+  int8: warp(32),
+  mxfp8: warp(32),
+  fp4: warp(64),
+  mxfp4: warp(64),
+  nvfp4: warp(64),
+};
+
+// Equal-throughput MFMA alternatives; wider output has half the K.
+// CDNA4's older instructions remain available at half its new peak.
+// https://rocm.blogs.amd.com/software-tools-optimization/matrix-cores-cdna/README.html
+const mfma = (k: number, rate = 1): MmaShape[] => [
+  { m: 16, n: 16, k, rate },
+  { m: 32, n: 32, k: k / 2, rate },
+];
+export const CDNA3_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: mfma(16),
+  fp8: mfma(32),
+  int8: mfma(32),
+};
+export const CDNA4_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: [...mfma(32), ...mfma(16, 0.5)],
+  fp8: [...mfma(128), ...mfma(32, 0.5)],
+  int8: [...mfma(64), ...mfma(32, 0.5)],
+  mxfp8: mfma(128),
+  fp4: mfma(128),
+  mxfp4: mfma(128),
+};
+
+// Gaudi's 256x256 array holds outputs while K streams through; k=1 skips K
+// padding. Startup/drain and Gaudi2's configurable geometries are unmodeled.
+// https://cdrdv2-public.intel.com/839363/Intel-Gaudi2-AI-Accelerators-whitepaper.pdf
+// https://cdrdv2-public.intel.com/845118/gaudi-3-ai-accelerator-30-3-30.pdf
+const gaudi: MmaShape[] = [{ m: 256, n: 256, k: 1, rate: 1 }];
+export const GAUDI_MMA: MmaShapes = { ...APPROXIMATE_MMA, bf16: gaudi, fp8: gaudi };
+
+// Effective pipelined tiles: wide stationary inputs have a 64-cycle issue
+// floor. Either operand can be stationary. Trn2's double-FP8 mode doubles K.
+// These approximate throughput, not minimum legal instruction dimensions.
+// https://awsdocs-neuron.readthedocs-hosted.com/en/v2.26.0/general/nki/api/generated/nki.isa.nc_matmul.html
+// https://awsdocs-neuron.readthedocs-hosted.com/en/v2.32.0/nki/guides/architecture/trainium2_arch.html#double-fp8-matmul-performance
+const neuron = (k: number): MmaShape[] => orientations(64, 128, k);
+// NeuronCore-v2 has native INT8, but the NKI timing model above covers only
+// floating point. INT8 retains the legacy 128³ estimate; its geometry is unknown.
+// https://awsdocs-neuron.readthedocs-hosted.com/en/v2.26.1/about-neuron/arch/neuron-hardware/neuron-core-v2.html
+export const NEURON_V2_MMA: MmaShapes = { ...APPROXIMATE_MMA, bf16: neuron(128), fp8: neuron(128) };
+export const NEURON_V3_MMA: MmaShapes = { ...NEURON_V2_MMA, fp8: neuron(256) };
+
+// Streamed MXU work: v5p-era BF16 issues 8x128 @ 128x128 every 8 cycles.
+// Later arrays are 256x256; retaining 8 rows is an approximation. Extending
+// BF16 geometry to packed formats is also inferred. Startup is unmodeled.
+// Swapping operands covers thin N; layout conversion costs are omitted.
+// https://jax-ml.github.io/scaling-book/tpus/#appendix-b-how-does-a-systolic-array-work
+// https://docs.cloud.google.com/tpu/docs/performance-guide
+const tpu = (width: number): MmaShape[] => orientations(8, width, width);
+export const TPU_V5P_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: tpu(128),
+  int8: tpu(128),
+  int4: tpu(128),
+};
+export const TPU_V6E_MMA: MmaShapes = {
+  ...APPROXIMATE_MMA,
+  bf16: tpu(256),
+  int8: tpu(256),
+  int4: tpu(256),
+};
+export const TPU_V7X_MMA: MmaShapes = { ...APPROXIMATE_MMA, bf16: tpu(256), fp8: tpu(256) };

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -523,7 +523,7 @@ function specJson(c: UiChip): string {
     hbmBandwidth: c.hbmBandwidth,
     interconnect: c.interconnect,
     ...(c.tdp !== undefined && { tdp: c.tdp }),
-    ...(c.matmulSatRows !== undefined && { matmulSatRows: c.matmulSatRows }),
+    mmaShapes: c.mmaShapes,
   };
   return JSON.stringify(spec, null, 2).replace(/-?\d[\d.]*(e[+-]?\d+)?/g, (s) => {
     const v = Number(s);

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,7 @@
+import type { MmaShape, MmaShapes } from '../src/core/hardware/mma';
+import { DTYPES } from '../src/core/model/dtype';
+
+// Conservation tests count useful FLOPs without padding or instruction-rate losses.
+export const IDEAL_MMA = Object.fromEntries<readonly MmaShape[]>(
+  DTYPES.map((dtype) => [dtype, [{ m: 1, n: 1, k: 1, rate: 1 }]]),
+) as MmaShapes;

--- a/tests/lowering.fuzz.test.ts
+++ b/tests/lowering.fuzz.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'vitest';
+import { IDEAL_MMA } from './fixtures';
 import { fuzzTest } from './fuzz';
 import { randAxes, randPlacement } from './gen';
 import { evaluatePrefill } from '../src/core/engine/sim/run/prefill';
@@ -35,9 +36,7 @@ const chip: ChipSpec = {
   interconnect: { bandwidthPerChip: 4e11, latency: 0, domainSize: 64 },
   realizableFlopsFrac: 0.8,
   realizableHbmBwFrac: 0.85,
-  // 1x1 matmul tiles: these oracles check conservation, so random
-  // unaligned dims must not pay tile padding
-  matmulSatRows: 1,
+  mmaShapes: IDEAL_MMA,
 };
 const hbm = chip.hbmBandwidth * chip.realizableHbmBwFrac;
 

--- a/tests/presets.conserve.test.ts
+++ b/tests/presets.conserve.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { IDEAL_MMA } from './fixtures';
 import { evaluatePrefill } from '../src/core/engine/sim/run/prefill';
 import { makeNaiveOpCostSumBackend } from '../src/core/engine/sim/cost/naiveOpCostSum';
 import { Deployment, makeMesh } from '../src/core/engine/surface/deploy';
@@ -21,7 +22,7 @@ const chip: ChipSpec = {
   interconnect: { bandwidthPerChip: 4e11, latency: 0, domainSize: 64 },
   realizableFlopsFrac: 0.8,
   realizableHbmBwFrac: 0.85,
-  matmulSatRows: 1,
+  mmaShapes: IDEAL_MMA,
 };
 const hbm = chip.hbmBandwidth * chip.realizableHbmBwFrac;
 function singleChip(): Deployment {

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { IDEAL_MMA } from './fixtures';
 import { evaluatePrefill } from '../src/core/engine/sim/run/prefill';
 import { evaluateDecodeAtBatch } from '../src/core/engine/sim/run/decode';
 import { memoryFootprint } from '../src/core/engine/sim/run/memory';
@@ -9,11 +10,19 @@ import { OpId } from '../src/core/engine/sim/ir/ops';
 import { localElems, tt } from '../src/core/engine/sim/ir/tensors';
 import { runnableOn, validateInput } from '../src/core/engine/sim/run/validate';
 import { Deployment, makeMesh, MoeDispatch } from '../src/core/engine/surface/deploy';
-import { ChipSpec, CHIPS_BY_ID, peakFlops, runsAs } from '../src/core/hardware/chips';
+import { ChipSpec, CHIPS, CHIPS_BY_ID, peakFlops, runsAs } from '../src/core/hardware/chips';
 import { deployedAxes } from '../src/core/hardware/topology';
 import { gqa } from '../src/core/model/block/attn';
 import { MlpConfig, moeMlp } from '../src/core/model/block/mlp';
-import { ALL_BF16, BF16_ALL, DTYPE_BYTES, FP8_ALL, PrecisionSpec } from '../src/core/model/dtype';
+import {
+  ALL_BF16,
+  BF16_ALL,
+  DTYPES,
+  DTYPE_BYTES,
+  FP8_ALL,
+  PrecisionSpec,
+  type Dtype,
+} from '../src/core/model/dtype';
 import { ModelSpec, MODEL_PRESETS } from '../src/core/model/models';
 import { flopsPerPrefillToken, kvBytesPerSeq, weightBytesTotal } from '../src/core/model/utils';
 import { matmulSeconds } from '../src/core/engine/roofline';
@@ -21,9 +30,7 @@ import { matmulSeconds } from '../src/core/engine/roofline';
 const backend = makeNaiveOpCostSumBackend({ memoryOverlap: 0, commsOverlap: 0 });
 const h100 = CHIPS_BY_ID['h100-sxm'];
 const hbm = h100.hbmBandwidth * h100.realizableHbmBwFrac;
-// 1x1 matmul tiles: the closed-form tests check FLOP conservation, so
-// tile-padding utilization is priced out (and pinned separately below)
-const idealTiles: typeof h100 = { ...h100, matmulSatRows: 1 };
+const idealTiles: ChipSpec = { ...h100, mmaShapes: IDEAL_MMA };
 
 test('validateInput gates weights past HBM capacity', () => {
   const kimi = MODEL_PRESETS.find((m) => m.name.startsWith('Kimi K2.6'))!;
@@ -263,48 +270,252 @@ test('single-chip dense prefill memory matches weights plus KV writes', () => {
   expect((r.cost.busy.memory - acts / hbm) / (bytes / hbm)).toBeCloseTo(1, 6);
 });
 
-test('thin GEMM dims pay tile padding', () => {
-  const ctx = singleChip(h100);
-  const time = (m: number, k: number, n: number) =>
-    naiveOpCost(
-      {
-        kind: 'gemm',
-        id: 'g' as OpId,
-        label: 'g',
-        deps: [],
-        x: tt([m, k]),
-        w: tt([k, n]),
-        out: tt([m, n]),
-        dtype: 'bf16',
-      },
-      ctx,
-    ).compute;
-
-  // any dim below the 128 tile costs the same as the padded full tile
-  const full = time(128, 128, 128);
-  expect(time(64, 128, 128)).toBeCloseTo(full, 15);
-  expect(time(128, 64, 128)).toBeCloseTo(full, 15);
-  expect(time(128, 128, 64)).toBeCloseTo(full, 15);
-  // aligned shapes pay none: pure flops ratio
-  expect(time(256, 128, 128) / full).toBeCloseTo(2, 9);
-});
-
-test('a gemm charges its activation streams to memory', () => {
-  const ctx = singleChip(h100);
-  const [m, k, n] = [256, 512, 1024];
-  const cost = naiveOpCost(
+function gemmCost(
+  chip: ChipSpec,
+  m: number,
+  k = 128,
+  n = 128,
+  groups?: number,
+  dtype: Dtype = 'bf16',
+) {
+  return naiveOpCost(
     {
       kind: 'gemm',
       id: 'g' as OpId,
       label: 'g',
       deps: [],
       x: tt([m, k]),
-      w: tt([k, n]),
+      w: tt(groups === undefined ? [k, n] : [groups, k, n]),
       out: tt([m, n]),
-      dtype: 'bf16',
+      dtype,
+      groups,
     },
-    ctx,
+    singleChip(chip),
   );
+}
+
+test('dense GEMMs use the chip shapes for M, N and K', () => {
+  const time = (m: number, k: number, n: number) => gemmCost(h100, m, k, n).compute;
+  const full = time(128, 128, 128);
+  expect(time(64, 128, 128) / full).toBeCloseTo(0.5, 9);
+  expect(time(128, 64, 128) / full).toBeCloseTo(0.5, 9);
+  expect(time(128, 128, 64) / full).toBeCloseTo(0.5, 9);
+  expect(time(128, 8, 128)).toBe(time(128, 16, 128));
+  expect(time(8, 128, 128)).toBe(time(128, 128, 8));
+  expect(time(256, 128, 128) / full).toBeCloseTo(2, 9);
+});
+
+test('grouped GEMMs require at least one tile per active expert', () => {
+  const time = (chip: ChipSpec, m: number, groups?: number) =>
+    gemmCost(chip, m, 128, 128, groups).compute;
+  // 256 rows over 111 groups: swapped warp paths use eight-row tiles;
+  // Rubin currently models only wide instructions with 128-row output tiles.
+  for (const [id, rows, rate] of [
+    ['h100-sxm', 8, 0.67],
+    ['a100-sxm', 8, 1],
+    ['b200', 8, 0.25],
+    ['vr100-nvl72', 128, 1],
+  ] as const) {
+    const chip = CHIPS_BY_ID[id];
+    expect(time(chip, 256, 111) / time(chip, 256)).toBeCloseTo((111 * rows) / rate / 256, 9);
+  }
+  const dense = time(h100, 256);
+  expect(time(h100, 2, 1) / dense).toBeCloseTo(8 / 0.67 / 256, 9);
+  // Register-A/shared-B WGMMA reaches near-full throughput at 32 rows per group.
+  expect(time(h100, 4096, 128) / dense).toBeCloseTo(4096 / 256, 9);
+  expect(time(h100, 8192, 128) / dense).toBeCloseTo(8192 / 256, 9);
+});
+
+test('Blackwell small GEMMs trade padding against measured instruction rates', () => {
+  for (const id of ['b200', 'gb200-nvl72', 'b300']) {
+    const chip = CHIPS_BY_ID[id];
+    for (const dtype of ['bf16', 'fp8'] as const) {
+      const time = (m: number, n = 4096) => gemmCost(chip, m, 128, n, undefined, dtype).compute;
+      const full = time(128);
+      // Equivalent full-rate rows, including the slower small-instruction path.
+      for (const [m, bf16Rows, fp8Rows] of [
+        [1, 32, 64],
+        [8, 32, 64],
+        [16, 64, 80],
+        [32, 80, 80],
+        [64, 96, 96],
+      ]) {
+        expect(time(m) / full).toBeCloseTo((dtype === 'bf16' ? bf16Rows : fp8Rows) / 128, 12);
+        expect(time(m)).toBe(time(4096, m));
+      }
+      // Both output dimensions can be small; a wide tile or warp alone loses.
+      expect(time(64, 64) / time(128, 128)).toBeCloseTo(0.5, 12);
+      expect(time(64, 32) / time(128, 128)).toBeCloseTo(0.375, 12);
+    }
+  }
+});
+
+test('Blackwell block-scaled GEMMs use narrower N without assuming native M64', () => {
+  for (const id of ['b200', 'gb200-nvl72']) {
+    for (const dtype of ['mxfp8', 'fp4', 'mxfp4', 'nvfp4'] as const) {
+      const k = dtype === 'mxfp8' ? 32 : 64;
+      const time = (m: number, n = 4096, reduction = k) =>
+        gemmCost(CHIPS_BY_ID[id], m, reduction, n, undefined, dtype).compute;
+      expect(time(32) / time(128)).toBeCloseTo(80 / 128, 12);
+      expect(time(64) / time(128)).toBeCloseTo(96 / 128, 12);
+      expect(time(32)).toBe(time(4096, 32));
+      expect(time(64, 64) / time(128, 128)).toBeCloseTo(0.75, 12);
+      expect(time(128, 128, k / 2)).toBe(time(128, 128));
+      expect(time(128, 128, k + 1) / time(128, 128)).toBeCloseTo(2, 12);
+    }
+  }
+});
+
+test('B300 FP4 reaches its higher peak only with larger tiles', () => {
+  for (const dtype of ['fp4', 'mxfp4', 'nvfp4'] as const) {
+    const time = (id: string, m: number, k: number, n: number) =>
+      gemmCost(CHIPS_BY_ID[id], m, k, n, undefined, dtype).compute;
+    // Equal work below the larger tile still runs at B200's throughput.
+    expect(time('b300', 128, 192, 128) / time('b200', 128, 192, 128)).toBeCloseTo(1, 12);
+    expect(time('b300', 128, 192, 256) / time('b200', 128, 192, 256)).toBeCloseTo(0.75, 12);
+    expect(time('b300', 256, 192, 256) / time('b200', 256, 192, 256)).toBeCloseTo(2 / 3, 12);
+    // The estimator can choose either reduction width instead of always padding to 96.
+    expect(time('b300', 128, 64, 128) / time('b300', 128, 96, 128)).toBeCloseTo(2 / 3, 12);
+  }
+});
+
+test('Rubin GEMMs use format-specific reduction widths', () => {
+  const chip = CHIPS_BY_ID['vr100-nvl72'];
+  for (const [dtype, k] of [
+    ['bf16', 16],
+    ['fp8', 64],
+    ['mxfp8', 64],
+    ['fp4', 128],
+    ['mxfp4', 128],
+    ['nvfp4', 128],
+  ] as const) {
+    const time = (reduction: number, groups = 1) =>
+      gemmCost(chip, 128, reduction, 128, groups, dtype).compute;
+    expect(time(k / 2)).toBe(time(k));
+    expect(time(k + 1) / time(k)).toBeCloseTo(2, 12);
+    expect(time(k, 2) / time(k)).toBeCloseTo(2, 12);
+    expect(gemmCost(chip, 128, k, 128, undefined, dtype).compute).toBe(time(k));
+  }
+});
+
+test('TPU expert work uses streamed rows and generation-specific array widths', () => {
+  for (const id of ['tpu-v5p', 'tpu-v6e', 'tpu-v7x']) {
+    const chip = CHIPS_BY_ID[id];
+    const width = id === 'tpu-v5p' ? 128 : 256;
+    const time = (m: number, k = width, n = width, groups = 1) =>
+      gemmCost(chip, m, k, n, groups).compute;
+    expect(time(1)).toBe(time(8));
+    expect(time(8)).toBe(time(width, width, 8));
+    expect(time(16) / time(8)).toBeCloseTo(2, 12);
+    expect(time(16, width, width, 8) / time(16)).toBeCloseTo(4, 12);
+    expect(time(8, width / 2, width / 2)).toBe(time(8));
+    expect(time(8, width + 1) / time(8)).toBeCloseTo(2, 12);
+  }
+});
+
+test('Neuron uses either orientation and Trainium2 FP8 doubles contraction width', () => {
+  for (const id of ['inferentia2', 'trainium1', 'trainium2']) {
+    const chip = CHIPS_BY_ID[id];
+    expect(gemmCost(chip, 1).compute).toBe(gemmCost(chip, 64).compute);
+    expect(gemmCost(chip, 64).compute).toBe(gemmCost(chip, 128, 128, 64).compute);
+  }
+  const chip = CHIPS_BY_ID['trainium2'];
+  const time = (k: number, dtype: Dtype) => gemmCost(chip, 64, k, 128, 1, dtype).compute;
+  expect(time(128, 'fp8')).toBe(time(256, 'fp8'));
+  expect(time(256, 'bf16') / time(128, 'bf16')).toBeCloseTo(2, 12);
+  expect(time(256, 'fp8') / time(256, 'bf16')).toBeCloseTo(
+    peakFlops(chip, 'bf16')! / peakFlops(chip, 'fp8')!,
+    12,
+  );
+});
+
+test('Gaudi pads the output array while streaming the reduction dimension', () => {
+  for (const id of ['gaudi2', 'gaudi3']) {
+    const chip = CHIPS_BY_ID[id];
+    const time = (m: number, k: number, n: number) => gemmCost(chip, m, k, n).compute;
+    expect(time(128, 17, 128)).toBe(time(256, 17, 256));
+    expect(time(256, 34, 256) / time(256, 17, 256)).toBeCloseTo(2, 12);
+  }
+});
+
+test('every chip declares valid shapes for each arithmetic dtype', () => {
+  for (const chip of CHIPS)
+    for (const dtype of DTYPES) {
+      expect(chip.mmaShapes[dtype].length).toBeGreaterThan(0);
+      for (const s of chip.mmaShapes[dtype]) {
+        for (const dim of [s.m, s.n, s.k]) expect(Number.isInteger(dim) && dim > 0).toBe(true);
+        expect(s.rate).toBeGreaterThan(0);
+        expect(s.rate).toBeLessThanOrEqual(1);
+      }
+    }
+});
+
+test('dense and one-group GEMMs have identical costs on every chip and native dtype', () => {
+  for (const chip of CHIPS)
+    for (const dtype of DTYPES.filter((d) => peakFlops(chip, d)))
+      for (const m of [2, 16.25, 64, 129])
+        expect(gemmCost(chip, m, 33, 19, 1, dtype)).toEqual(
+          gemmCost(chip, m, 33, 19, undefined, dtype),
+        );
+});
+
+test('Hopper small FP8 shapes use the widening rate, large shapes use native FP8', () => {
+  const time = (m: number, dtype: Dtype) => gemmCost(h100, m, 128, 128, undefined, dtype).compute;
+  expect(time(2, 'fp8') / time(2, 'bf16')).toBeCloseTo(1, 2);
+  expect(time(128, 'fp8') / time(128, 'bf16')).toBeCloseTo(0.5, 3);
+  // Native FP8 at 16 rows is ~60% of FP8 peak; 32 rows is near full rate.
+  expect(time(16, 'fp8') / time(128, 'fp8')).toBeCloseTo(16 / 0.6 / 128, 12);
+  for (const dtype of ['bf16', 'fp8'] as const) {
+    expect(time(32, dtype) / time(128, dtype)).toBeCloseTo(0.25, 12);
+    expect(time(32, dtype)).toBe(gemmCost(h100, 128, 128, 32, undefined, dtype).compute);
+  }
+});
+
+test('shape costs include N/K padding and rate without changing memory traffic', () => {
+  const chip: ChipSpec = {
+    ...h100,
+    mmaShapes: {
+      ...h100.mmaShapes,
+      bf16: [
+        { m: 8, n: 128, k: 128, rate: 1 },
+        { m: 16, n: 8, k: 16, rate: 0.5 },
+      ],
+    },
+  };
+  // The larger M wins for thin N/K despite running at half rate.
+  const narrow = gemmCost(chip, 8, 16, 8);
+  const ideal = gemmCost(idealTiles, 8, 16, 8);
+  expect(narrow.compute / ideal.compute).toBeCloseTo(4, 9);
+  expect(narrow.memory).toBe(ideal.memory);
+  expect(gemmCost(chip, 8).compute).toBe(gemmCost(idealTiles, 8).compute);
+  expect(gemmCost(chip, 0, 128, 128, 111).compute).toBe(0);
+  // Unit tiles also leave fractional analytical dimensions unrounded.
+  expect(gemmCost(idealTiles, 0.5, 16.25, 8.5, 111).compute).toBe(
+    (2 * 0.5 * 16.25 * 8.5) / (peakFlops(h100, 'bf16')! * h100.realizableFlopsFrac),
+  );
+});
+
+test('gpt-oss-120b decode on one H200 stays under the measured step time', () => {
+  // InferenceX gptoss-fp4-h200-trt, TP=1, 1k/1k, concurrency 64: median
+  // TPOT 22.5 ms (github.com/SemiAnalysisAI/InferenceX, run 26016892349)
+  const measured = 22.5e-3;
+  const model = MODEL_PRESETS.find((m) => m.name === 'gpt-oss-120b MXFP4/BF16')!;
+  const h200 = CHIPS_BY_ID['h200-sxm'];
+  const result = evaluateDecodeAtBatch(
+    { model, deployment: singleChip(h200), workload: { prefillLen: 1024, generateLen: 1024 } },
+    64,
+    1,
+    { costBackend: makeNaiveOpCostSumBackend({ memoryOverlap: 0.9, commsOverlap: 0.65 }) },
+  );
+  if (!result.ok) throw new Error(result.diags.map((x) => x.message).join(', '));
+  expect(result.stepTime).toBeLessThan(measured);
+  // Weight traffic dominates decode at this batch.
+  expect(result.cost.busy.memory).toBeGreaterThan(result.cost.busy.compute);
+});
+
+test('a gemm charges its activation streams to memory', () => {
+  const [m, k, n] = [256, 512, 1024];
+  const cost = gemmCost(h100, m, k, n);
   // rows in and rows out; the weights are priced by their own load node
   expect(cost.memory).toBeCloseTo((m * (k + n) * 2) / hbm, 15);
 });


### PR DESCRIPTION
Padding every GEMM dimension to 128 overestimates the compute cost of small matrices. Replace `matmulSatRows` with per-chip, per-dtype M/N/K shapes and relative instruction rates. Dense and grouped GEMMs choose the least expensive padded work across those shapes; grouped GEMMs also require at least one tile per estimated active expert.

The tables include measured floating-point instruction rates on H100, B200 and B300, along with documented shapes or throughput approximations for other NVIDIA, AMD, TPU, Trainium/Inferentia and Gaudi chips. Source links and assumptions live beside the tables. Rubin uses documented wide shapes without assuming measured small-shape rates; uncharacterized paths retain an explicit approximation.

This estimates arithmetic time. Individual expert group sizes remain approximated, and layout conversion, unpacking and launch overhead are omitted. Memory traffic continues to use unpadded tensor sizes.

The independent per-layer MoE routing fix and unused-code removal were merged separately in #3. This PR contains only the MMA implementation, hardware data, spec serialization and tests. It builds on Travis Chen’s work in #2; he is credited as a co-author on the commit.

Validation: all 100 tests pass, including padding boundaries, measured-rate expectations, dense/one-group equivalence and search benchmarks; production build and repository-wide formatting checks pass. The combined tracked tree is identical to the code before the PR split.
